### PR TITLE
Switch dependency from hashie to recursive-open-struct

### DIFF
--- a/actionizer.gemspec
+++ b/actionizer.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'hashie'
+  spec.add_runtime_dependency 'recursive-open-struct'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/actionizer.rb
+++ b/lib/actionizer.rb
@@ -1,3 +1,4 @@
+require 'recursive_open_struct'
 require 'actionizer/result'
 require 'actionizer/failure'
 require 'actionizer/version'
@@ -28,7 +29,7 @@ module Actionizer
   end
 
   def initialize(initial_input = {})
-    @input = Hashie::Mash.new(initial_input)
+    @input = RecursiveOpenStruct.new(initial_input)
     @output = Actionizer::Result.new
   end
 

--- a/lib/actionizer/result.rb
+++ b/lib/actionizer/result.rb
@@ -1,12 +1,11 @@
-require 'hashie'
+require 'recursive_open_struct'
 
 module Actionizer
-  class Result < Hashie::Mash
+  class Result < RecursiveOpenStruct
 
     def initialize(initial_hash = {})
       @success = true
-
-      initial_hash.each_pair { |key, value| self[key] = value }
+      super(initial_hash, preserve_original_keys: true)
     end
 
     def success?

--- a/lib/actionizer/version.rb
+++ b/lib/actionizer/version.rb
@@ -1,3 +1,3 @@
 module Actionizer
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/actionizer/result_spec.rb
+++ b/spec/actionizer/result_spec.rb
@@ -2,40 +2,64 @@ require 'spec_helper'
 
 module Actionizer
   describe Result do
-    let(:result) { described_class.new }
+    subject { described_class.new(initial_hash) }
+    let(:initial_hash) { {} }
 
     describe '#initialize' do
       let(:initial_hash) { { foo: 'value' } }
-      let(:result) { described_class.new(initial_hash) }
 
       it 'defaults to being successful' do
-        expect(result).to be_success
+        expect(subject).to be_success
       end
 
       it 'allows you to pass a hash' do
-        expect(result.foo).to eq(initial_hash[:foo])
+        expect(subject.foo).to eq(initial_hash[:foo])
+      end
+
+      context 'when initialized with non-symbol keys' do
+        let(:value) { 'some_value' }
+        let(:initial_hash) { { 'string_key' => value } }
+
+        it 'allows indifferent access' do
+          expect(subject.string_key).to eq(value)
+          expect(subject['string_key']).to eq(value)
+          expect(subject[:string_key]).to eq(value)
+        end
       end
     end
 
     it 'has a success? method' do
-      expect(result).to respond_to(:success?)
+      expect(subject).to respond_to(:success?)
     end
 
     it 'has a failure? method' do
-      expect(result).to respond_to(:failure?)
+      expect(subject).to respond_to(:failure?)
+    end
+
+    describe '#to_h' do
+      it 'works as expected' do
+        expect(subject.to_h).to eq(initial_hash)
+      end
+
+      context 'when initialized with non-symbol keys' do
+        let(:initial_hash) { { 'string_key' => 'val', symbol_key: 'val', 123 => 'val' } }
+        it 'does not modify key types' do
+          expect(subject.to_h).to eq(initial_hash)
+        end
+      end
     end
 
     describe '#fail' do
       it 'changes the state to be failure' do
-        expect(result).to be_success
-        result.fail
-        expect(result).to be_failure
+        expect(subject).to be_success
+        subject.fail
+        expect(subject).to be_failure
       end
     end
 
     it 'allows arbitrary fields to be set' do
-      result.field = 'value'
-      expect(result.field).to eq('value')
+      subject.field = 'value'
+      expect(subject.field).to eq('value')
     end
   end
 end


### PR DESCRIPTION
Hashie::Mash coerces all keys to strings. We don't want that.