### PR TITLE
Relax ruby version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.2
+  - 2.0.0
   - 2.3.0
 before_install: gem install bundler -v 1.11.2
 script: rubocop -D && bundle exec rspec

--- a/actionizer.gemspec
+++ b/actionizer.gemspec
@@ -26,8 +26,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.2.2'
-
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/actionizer.gemspec
+++ b/actionizer.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '~> 2.0'
+
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/actionizer/version.rb
+++ b/lib/actionizer/version.rb
@@ -1,3 +1,3 @@
 module Actionizer
-  VERSION = '0.7.2'
+  VERSION = '0.7.3'
 end


### PR DESCRIPTION
The previous version downgrade was not backwards-compatible because of the patch version and the fact that I used `~>` to specify the version requirement. Since I originally added the version requirement as more of a suggestion to upgrade to the newest version of ruby, I'm removing it because I don't have a good reason to enforce a particular version.