### PR TITLE
Allow action classes to rescue StandardError

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+Lint/InheritException:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 25
 Metrics/LineLength:
@@ -16,6 +19,4 @@ Style/FrozenStringLiteralComment:
 Style/MutableConstant:
   Enabled: false
 Style/NegatedIf:
-  Enabled: false
-Style/TrivialAccessors:
   Enabled: false

--- a/lib/actionizer/failure.rb
+++ b/lib/actionizer/failure.rb
@@ -1,5 +1,5 @@
 module Actionizer
-  class Failure < StandardError
+  class Failure < Exception
     attr_reader :output
 
     def initialize(msg, output)

--- a/lib/actionizer/version.rb
+++ b/lib/actionizer/version.rb
@@ -1,3 +1,3 @@
 module Actionizer
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end

--- a/spec/actionizer/failure_spec.rb
+++ b/spec/actionizer/failure_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Actionizer::Failure do
+  context 'when an action class rescues StandardError' do
+    let(:dummy_class) do
+      Class.new do
+        include Actionizer
+        def call
+          fail!(error: 'error')
+        rescue StandardError
+          raise StandardError, 'Should not rescue from Actionizer::Failure'
+        end
+      end
+    end
+    let(:result) { dummy_class.call }
+
+    it "doesn't stop the action from working properly" do
+      expect(result).to be_failure
+    end
+  end
+end


### PR DESCRIPTION
I want to allow action classes to rescue from a broad range of exceptions by enabling them to rescue from `StandardError`. When `Actionizer::Failure` inherited from `StandardError`, it would potentially cause the `fail!` mechanism not to work properly. Now that `Actionizer::Failure` inherits from `Exception`, there is no potential for this issue.