### PR TITLE
Change errors found while processing inputs to not raise an exception

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,11 +14,14 @@ Metrics/MethodLength:
 
 Style/Documentation:
   Enabled: false
+
 Style/EmptyLinesAroundBlockBody:
   Enabled: false
 Style/EmptyLinesAroundClassBody:
   Enabled: false
 Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/IfUnlessModifier:
   Enabled: false
 Style/MutableConstant:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To more explicitly document the inputs to your Actions, you can use `inputs_for`
 class CreateUser
   include Actionizer
 
-  inputs_for :call do
+  inputs_for(:call) do
     required :name
     required :email
     optional :phone_number
@@ -156,7 +156,27 @@ class CreateUser
 end
 ```
 
-You'll get an `ArgumentError` if you pass any params not defined in the `inputs_for` block, or if you don't supply all required params. This is completely opt-in so if you don't provide an `inputs_for` block, no checking is performed.
+### Specifying types and nullable fields
+
+You can now also optionally specify types and nullability for your inputs. For the `type:` option, any ruby class can be used.
+
+```ruby
+inputs_for(:call) do
+  required :name, type: String, null: false
+  required :email, null: false
+  optional :phone_number, type: Integer
+end
+```
+
+### `inputs_for` error handling
+
+The action will fail immediately if any of the conditions are met:
+- Any required param is not passed
+- A param is passed that is not declared
+- `nil` is passed for a param marked `null: false` (default is `null: true`)
+- The class of the argument is not equal to or a subclass of the specified type
+
+Using an `inputs_for` block is completely opt-in so if you don't provide it, no checking is performed.
 
 ## Development
 

--- a/actionizer.gemspec
+++ b/actionizer.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 11.3'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'pry-byebug', '~> 3.4'
-  spec.add_development_dependency 'rubocop', '~> 0.45'
+  spec.add_development_dependency 'rubocop', '0.45.0'
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.5'
 end

--- a/lib/actionizer.rb
+++ b/lib/actionizer.rb
@@ -17,7 +17,9 @@ module Actionizer
 
       if instance.respond_to?(method_name)
         error = defined_inputs.check_for_param_error(method_name, *args)
-        raise ArgumentError, error if error
+        if error
+          return Actionizer::Result.new(error: error).tap(&:fail)
+        end
 
         instance.tap(&method_name).output
       else

--- a/lib/actionizer/version.rb
+++ b/lib/actionizer/version.rb
@@ -1,3 +1,3 @@
 module Actionizer
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end

--- a/spec/actionizer/inputs_spec.rb
+++ b/spec/actionizer/inputs_spec.rb
@@ -51,8 +51,10 @@ describe Actionizer do
           def call; end
         end
       end
-      it 'raises an error' do
-        expect { failing_class.call(bar: 'oops') }.to raise_error(ArgumentError)
+      it 'fails gracefully and sets the error message' do
+        result = failing_class.call(bar: 'oops')
+        expect(result).to be_failure
+        expect(result.error).not_to be_nil
       end
     end
 
@@ -67,8 +69,10 @@ describe Actionizer do
           def call; end
         end
       end
-      it 'raises an error' do
-        expect { failing_class.call(foo: 'present') }.to raise_error(ArgumentError)
+      it 'fails gracefully and sets the error message' do
+        result = failing_class.call(foo: 'present')
+        expect(result).to be_failure
+        expect(result.error).not_to be_nil
       end
     end
 
@@ -166,8 +170,10 @@ describe Actionizer do
         end
 
         context 'and nil is passed' do
-          it 'fails' do
-            expect { dummy_class.call(arg: nil) }.to raise_error(ArgumentError)
+          it 'fails gracefully and sets the error message' do
+            result = dummy_class.call(arg: nil)
+            expect(result).to be_failure
+            expect(result.error).not_to be_nil
           end
         end
 
@@ -236,8 +242,10 @@ describe Actionizer do
         end
 
         context 'and a type other than a subclass is passed' do
-          it 'fails' do
-            expect { dummy_class.call(arg: '1') }.to raise_error(ArgumentError)
+          it 'fails gracefully and sets the error message' do
+            result = dummy_class.call(arg: '1')
+            expect(result).to be_failure
+            expect(result.error).not_to be_nil
           end
         end
 

--- a/spec/actionizer/inputs_spec.rb
+++ b/spec/actionizer/inputs_spec.rb
@@ -10,6 +10,7 @@ describe Actionizer do
           def call; end
         end
       end
+
       it 'raises an error' do
         expect { failing_class.call }.to raise_error(RuntimeError)
       end
@@ -23,6 +24,7 @@ describe Actionizer do
           def call; end
         end
       end
+
       it 'raises an error' do
         expect { failing_class.call }.to raise_error(RuntimeError)
       end
@@ -36,6 +38,7 @@ describe Actionizer do
           def call; end
         end
       end
+
       it 'raises an error' do
         expect { failing_class.call }.to raise_error(RuntimeError)
       end
@@ -51,10 +54,11 @@ describe Actionizer do
           def call; end
         end
       end
+
       it 'fails gracefully and sets the error message' do
         result = failing_class.call(bar: 'oops')
         expect(result).to be_failure
-        expect(result.error).not_to be_nil
+        expect(result.error).to eq('Param bar not declared')
       end
     end
 
@@ -69,10 +73,11 @@ describe Actionizer do
           def call; end
         end
       end
+
       it 'fails gracefully and sets the error message' do
         result = failing_class.call(foo: 'present')
         expect(result).to be_failure
-        expect(result.error).not_to be_nil
+        expect(result.error).to eq('Param bar is required for call')
       end
     end
 
@@ -87,8 +92,10 @@ describe Actionizer do
           def call; end
         end
       end
+
       it 'succeeds' do
-        succeeding_class.call(foo: 'present', bar: 'also present')
+        result = succeeding_class.call(foo: 'present', bar: 'also present')
+        expect(result).to be_success
       end
     end
 
@@ -104,8 +111,10 @@ describe Actionizer do
           def call; end
         end
       end
+
       it 'succeeds' do
-        succeeding_class.call(foo: 'present', qux: 'here')
+        result = succeeding_class.call(foo: 'present', qux: 'here')
+        expect(result).to be_success
       end
     end
 
@@ -115,7 +124,7 @@ describe Actionizer do
           Class.new do
             include Actionizer
             inputs_for(:call) do
-              optional :arg
+              optional :foo
             end
             def call; end
           end
@@ -123,13 +132,13 @@ describe Actionizer do
 
         context 'and nil is passed' do
           it 'succeeds' do
-            expect(dummy_class.call(arg: nil)).to be_success
+            expect(dummy_class.call(foo: nil)).to be_success
           end
         end
 
         context 'and not nil is passed' do
           it 'succeeds' do
-            expect(dummy_class.call(arg: 'not-nil')).to be_success
+            expect(dummy_class.call(foo: 'not-nil')).to be_success
           end
         end
       end
@@ -139,7 +148,7 @@ describe Actionizer do
           Class.new do
             include Actionizer
             inputs_for(:call) do
-              optional :arg, null: true
+              optional :foo, null: true
             end
             def call; end
           end
@@ -147,13 +156,13 @@ describe Actionizer do
 
         context 'and nil is passed' do
           it 'succeeds' do
-            expect(dummy_class.call(arg: nil)).to be_success
+            expect(dummy_class.call(foo: nil)).to be_success
           end
         end
 
         context 'and not nil is passed' do
           it 'succeeds' do
-            expect(dummy_class.call(arg: 'not-nil')).to be_success
+            expect(dummy_class.call(foo: 'not-nil')).to be_success
           end
         end
       end
@@ -163,7 +172,7 @@ describe Actionizer do
           Class.new do
             include Actionizer
             inputs_for(:call) do
-              optional :arg, null: false
+              optional :foo, null: false
             end
             def call; end
           end
@@ -171,15 +180,15 @@ describe Actionizer do
 
         context 'and nil is passed' do
           it 'fails gracefully and sets the error message' do
-            result = dummy_class.call(arg: nil)
+            result = dummy_class.call(foo: nil)
             expect(result).to be_failure
-            expect(result.error).not_to be_nil
+            expect(result.error).to eq("Param foo can't be nil")
           end
         end
 
         context 'and not nil is passed' do
           it 'succeeds' do
-            expect(dummy_class.call(arg: 'not-nil')).to be_success
+            expect(dummy_class.call(foo: 'not-nil')).to be_success
           end
         end
       end
@@ -189,14 +198,14 @@ describe Actionizer do
           Class.new do
             include Actionizer
             inputs_for(:call) do
-              optional :arg, null: 'not-true-or-false'
+              optional :foo, null: 'not-true-or-false'
             end
             def call; end
           end
         end
 
         it 'raises an ArgumentError' do
-          expect { dummy_class.call(arg: 'whatever') }.to raise_error(ArgumentError)
+          expect { dummy_class.call(foo: 'whatever') }.to raise_error(ArgumentError)
         end
       end
     end
@@ -207,14 +216,14 @@ describe Actionizer do
           Class.new do
             include Actionizer
             inputs_for(:call) do
-              optional :arg
+              optional :foo
             end
             def call; end
           end
         end
 
         it 'allows any type' do
-          expect(dummy_class.call(arg: :any_type_at_all)).to be_success
+          expect(dummy_class.call(foo: :any_type_at_all)).to be_success
         end
       end
 
@@ -223,7 +232,7 @@ describe Actionizer do
           Class.new do
             include Actionizer
             inputs_for(:call) do
-              optional :arg, type: Numeric
+              optional :foo, type: Numeric
             end
             def call; end
           end
@@ -231,21 +240,21 @@ describe Actionizer do
 
         context 'and that exact type is passed' do
           it 'succeeds' do
-            expect(dummy_class.call(arg: 1)).to be_success
+            expect(dummy_class.call(foo: 1)).to be_success
           end
         end
 
         context 'and a subclass of that type is passed' do
           it 'succeeds' do
-            expect(dummy_class.call(arg: 1.1)).to be_success
+            expect(dummy_class.call(foo: 1.1)).to be_success
           end
         end
 
         context 'and a type other than a subclass is passed' do
           it 'fails gracefully and sets the error message' do
-            result = dummy_class.call(arg: '1')
+            result = dummy_class.call(foo: '1')
             expect(result).to be_failure
-            expect(result.error).not_to be_nil
+            expect(result.error).to eq('Param foo must descend from Numeric')
           end
         end
 
@@ -254,14 +263,14 @@ describe Actionizer do
             Class.new do
               include Actionizer
               inputs_for(:call) do
-                optional :arg, type: 'not-a-class'
+                optional :foo, type: 'not-a-class'
               end
               def call; end
             end
           end
 
           it 'raises an ArgumentError' do
-            expect { dummy_class.call(arg: 'whatever') }.to raise_error(ArgumentError)
+            expect { dummy_class.call(foo: 'whatever') }.to raise_error(ArgumentError)
           end
         end
       end

--- a/spec/actionizer/inputs_spec.rb
+++ b/spec/actionizer/inputs_spec.rb
@@ -258,6 +258,14 @@ describe Actionizer do
           end
         end
 
+        context 'and nil is passed' do
+          it 'fails because of the type check, not because of the nil check' do
+            result = dummy_class.call(foo: nil)
+            expect(result).to be_failure
+            expect(result.error).to eq('Param foo must descend from Numeric')
+          end
+        end
+
         context 'and that thing is not a class' do
           let(:dummy_class) do
             Class.new do


### PR DESCRIPTION
This is because even though the contract is not being fulfilled, I believe that the called code also has a contract to behave in a certain well-defined way. That is, to return a failure with an explanation of why it can't do its specified task. Ideally, we would check for this thing at compile time but since ruby is an interpreted language, our options are limited.