### PR TITLE
Replace <METHOD>_or_fail(class) with class.<METHOD>!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/PerceivedComplexity:
 Metrics/LineLength:
   Max: 120
 Metrics/MethodLength:
-  Max: 15
+  Max: 20
 
 Style/Documentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
   - 2.1.0
-  - 2.3.1
-before_install: gem install bundler -v 1.13.6
+  - 2.4.1
+before_install: gem install bundler -v 1.15.3
 script: rubocop -D && bundle exec rspec
 addons:
   code_climate:

--- a/lib/actionizer/version.rb
+++ b/lib/actionizer/version.rb
@@ -1,3 +1,3 @@
 module Actionizer
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end


### PR DESCRIPTION
After much consideration and real-world usage, I've decide against the `<METHOD>_or_fail(class)` approach in favor of a simpler `class.<METHOD>!` approach. This makes it much clearer and more explicit that we're invoking a method on a class, and feels much more natural. This will be a backwards-incompatible change so be advised when upgrading.