### PR TITLE
Adding a check for if an input is a class

### DIFF
--- a/lib/actionizer/inputs.rb
+++ b/lib/actionizer/inputs.rb
@@ -23,17 +23,18 @@ module Actionizer
           return "Param #{param} can't be nil"
         end
 
-        type = attrs.fetch(:type)
-
-        # Type check if param was required, or if optional and passed in
-        if attrs.fetch(:required) || params.include?(param)
-          if type && !(params[param].class <= type)
-            return "Param #{param} must descend from #{type}"
-          end
-        end
-
         if attrs.fetch(:required) && !params.include?(param)
           return "Param #{param} is required for #{method_name}"
+        end
+
+        if !params.include?(param)
+          next
+        end
+
+        type = attrs.fetch(:type)
+        param_class = params[param].is_a?(Class) ? params[param] : params[param].class
+        if type && !(param_class <= type)
+          return "Param #{param} must descend from #{type}"
         end
       end
 

--- a/lib/actionizer/version.rb
+++ b/lib/actionizer/version.rb
@@ -1,3 +1,3 @@
 module Actionizer
-  VERSION = '0.14.0'
+  VERSION = '0.15.0'
 end

--- a/spec/actionizer/inputs_spec.rb
+++ b/spec/actionizer/inputs_spec.rb
@@ -282,6 +282,7 @@ describe Actionizer do
               expect(dummy_class.call(foo: Integer)).to be_success
             end
           end
+
           context 'and the arg passed is not a descendent' do
             it 'fails' do
               result = dummy_class.call(foo: String)

--- a/spec/actionizer/inputs_spec.rb
+++ b/spec/actionizer/inputs_spec.rb
@@ -276,6 +276,21 @@ describe Actionizer do
           end
         end
 
+        context 'and the type specified is a parent class' do
+          context 'and the arg passed is a descendent' do
+            it 'succeeds' do
+              expect(dummy_class.call(foo: Integer)).to be_success
+            end
+          end
+          context 'and the arg passed is not a descendent' do
+            it 'fails' do
+              result = dummy_class.call(foo: String)
+              expect(result).to be_failure
+              expect(result.error).to eq('Param foo must descend from Numeric')
+            end
+          end
+        end
+
         context 'and nil is passed' do
           it 'fails because of the type check, not because of the nil check' do
             result = dummy_class.call(foo: nil)


### PR DESCRIPTION
Then type-checking on the inheritance structure of the checked type instead of on the `.class` of the provided arg. It creates a new issue where somebody could do `type: Hash` and then feed in `.call(arg: Hash)` but you'd have to be a big idiot to abuse that in any meaningful way.