### PR TITLE
Add persistence parameters

### DIFF
--- a/lib/actionizer/inputs.rb
+++ b/lib/actionizer/inputs.rb
@@ -61,7 +61,9 @@ module Actionizer
 
       @declared_params_by_method[method][param] = { required: required,
                                                     null: opts[:null] != false,
-                                                    type: opts.fetch(:type, nil) }
+                                                    type: opts.fetch(:type, nil),
+                                                    persistence: opts[:persistence],
+                                                    local_persistence: opts[:local_persistence] }
     end
 
     def no_params_declared?(method)


### PR DESCRIPTION
Allow things like:

```
class Foo
  include Actionizer

  inputs_for :call do
    required :widget, persistence: WidgetPersistence
  end
  def call
    ...
  end
end

Foo.call(widget: 'b42ea2ef-17f9-4d42-972c-03fb9daf1561')
Foo.call(widget: { length: 1, width: 2})
```